### PR TITLE
Ohmmeter and Triangular Voltage Symbols

### DIFF
--- a/tex/latex/circuitikz/circuitikz.code.tex
+++ b/tex/latex/circuitikz/circuitikz.code.tex
@@ -1,4 +1,3 @@
-
 %% Options
 
 
@@ -95,6 +94,8 @@
 \ctikzset{bipoles/vsourcesin/width/.initial=.60}
 \ctikzset{bipoles/vsourcesquare/height/.initial=.60}
 \ctikzset{bipoles/vsourcesquare/width/.initial=.60}
+\ctikzset{bipoles/vsourcetri/height/.initial=.60}
+\ctikzset{bipoles/vsourcetri/width/.initial=.60}
 \ctikzset{bipoles/cisource/height/.initial=.7}
 \ctikzset{bipoles/cisource/width/.initial=.7}
 \ctikzset{bipoles/cisourceam/height/.initial=.7}
@@ -151,6 +152,8 @@
 \ctikzset{bipoles/open/width/.initial=.8}
 \ctikzset{bipoles/ammeter/height/.initial=.60}
 \ctikzset{bipoles/ammeter/width/.initial=.60}
+\ctikzset{bipoles/ohmmeter/height/.initial=.60}
+\ctikzset{bipoles/ohmmeter/width/.initial=.60}
 \ctikzset{bipoles/voltmeter/height/.initial=.60}
 \ctikzset{bipoles/voltmeter/width/.initial=.60}
 \ctikzset{bipoles/buffer/height/.initial=1}

--- a/tex/latex/circuitikz/circuitikz1.code.tex
+++ b/tex/latex/circuitikz/circuitikz1.code.tex
@@ -146,6 +146,7 @@
 \def\pgf@circ@isource@path#1{\pgf@circ@bipole@path{isource}{#1}}
 \def\pgf@circ@isourcesin@path#1{\pgf@circ@bipole@path{isourcesin}{#1}}
 \def\pgf@circ@vsourcesquare@path#1{\pgf@circ@bipole@path{vsourcesquare}{#1}}
+\def\pgf@circ@vsourcetri@path#1{\pgf@circ@bipole@path{vsourcetri}{#1}}
 \def\pgf@circ@isourceam@path#1{\pgf@circ@bipole@path{isourceAM}{#1}}
 \def\pgf@circ@cvsource@path#1{\pgf@circ@bipole@path{cvsource}{#1}}
 \def\pgf@circ@cvsourceam@path#1{\pgf@circ@bipole@path{cvsourceAM}{#1}}
@@ -178,6 +179,7 @@
 \def\pgf@circ@fullgeneric@path#1{\pgf@circ@bipole@path{fullgeneric}{#1}}
 \def\pgf@circ@tfullgeneric@path#1{\pgf@circ@bipole@path{tfullgeneric}{#1}}
 \def\pgf@circ@ammeter@path#1{\pgf@circ@bipole@path{ammeter}{#1}}
+\def\pgf@circ@ohmmeter@path#1{\pgf@circ@bipole@path{ohmmeter}{#1}}
 \def\pgf@circ@voltmeter@path#1{\pgf@circ@bipole@path{voltmeter}{#1}}
 \def\pgf@circ@empty@path#1{}
 \def\pgf@circ@photoresistor@path#1{\pgf@circ@bipole@path{photoresistor}{#1}}
@@ -204,6 +206,7 @@
 \tikzset{american resistor/.style= {\circuitikzbasekey, /tikz/to path=\pgf@circ@bipole@path{resistor}{#1}, l=#1}}
 \tikzset{european resistor/.style= {\circuitikzbasekey, /tikz/to path=\pgf@circ@bipole@path{generic}{#1}, l=#1}}
 \tikzset{ammeter/.style= {\circuitikzbasekey, /tikz/to path=\pgf@circ@ammeter@path, l=#1}}
+\tikzset{ohmmeter/.style= {\circuitikzbasekey, /tikz/to path=\pgf@circ@ohmmeter@path, l=#1}}
 \tikzset{voltmeter/.style= {\circuitikzbasekey, /tikz/to path=\pgf@circ@voltmeter@path, l=#1}}
 \tikzset{potentiometer/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@potentiometer@path, l=#1}}
 \tikzset{varistor/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@varistor@path, l=#1}}
@@ -242,6 +245,7 @@
 \tikzset{american controlled current source/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@cisourceam@path, \circuitikzbasekey/bipole/is current=true, i=#1}}
 \tikzset{sinusoidal voltage source/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@vsourcesin@path, \circuitikzbasekey/bipole/is voltage=true, v=#1 }}
 \tikzset{square voltage source/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@vsourcesquare@path, \circuitikzbasekey/bipole/is voltage=true, v=#1 }}
+\tikzset{triangle voltage source/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@vsourcetri@path, \circuitikzbasekey/bipole/is voltage=true, v=#1 }}
 \tikzset{sinusoidal current source/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@isourcesin@path, \circuitikzbasekey/bipole/is current=true, i=#1}}
 \tikzset{controlled sinusoidal voltage source/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@cvsourcesin@path, \circuitikzbasekey/bipole/is voltage=true, v=#1}}
 \tikzset{controlled sinusoidal current source/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@cisourcesin@path, \circuitikzbasekey/bipole/is current=true, i=#1}}
@@ -304,6 +308,7 @@
 \tikzset{toggle switch/.style =  {\circuitikzbasekey, /tikz/to path=\pgf@circ@toggleswitch@path}}
 
 \tikzset{ammeter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@ammeter@path}}
+\tikzset{ohmmeter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@ohmmeter@path}}
 \tikzset{voltmeter/.style = {\circuitikzbasekey, /tikz/to path=\pgf@circ@voltmeter@path}}
 
 % short forms
@@ -313,6 +318,7 @@
 \tikzset{cvsource/.style = {controlled voltage source = #1}}
 \tikzset{vsourcesin/.style = {sinusoidal voltage source = #1}}
 \tikzset{vsourcesquare/.style = {square voltage source = #1}}
+\tikzset{vsourcetri/.style = {triangle voltage source = #1}}
 \tikzset{isourcesin/.style = {sinusoidal current source = #1}}
 \tikzset{cisourcesin/.style = {controlled sinusoidal current source = #1}}
 \tikzset{cvsourcesin/.style = {controlled sinusoidal  voltage source = #1}}
@@ -338,6 +344,7 @@
 \tikzset{cV/.style = {controlled voltage source = #1}}
 \tikzset{sV/.style = {sinusoidal voltage source = #1}}
 \tikzset{sqV/.style = {square voltage source = #1}}
+\tikzset{tV/.style = {triangle voltage source = #1}}
 \tikzset{csV/.style = {controlled sinusoidal voltage source = #1}}
 \def\pgf@temp#1{ 
 	\tikzset{V#1/.style = {voltage source, v#1=##1} } 

--- a/tex/latex/circuitikz/pgfcircbipoles.sty
+++ b/tex/latex/circuitikz/pgfcircbipoles.sty
@@ -440,6 +440,24 @@
 		\endpgfscope
 }
 
+% Triangle Voltage source – contributed by Ralf Farkas
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/vsourcetri/height}}{vsourcetri}{\ctikzvalof{bipoles/vsourcetri/height}}{\ctikzvalof{bipoles/vsourcetri/width}}{
+
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+	\pgfpathellipse{\pgfpointorigin}{\pgfpoint{0}{\pgf@circ@res@up}}{\pgfpoint{\pgf@circ@res@left}{0}}
+	\pgfusepath{draw}		
+		
+		\pgf@circ@res@up = .5\pgf@circ@res@up
+		\pgfscope
+			\pgftransformrotate{90}
+			\pgfpathmoveto{\pgfpoint{-1\pgf@circ@res@up}{0cm}}
+			\pgfpathlineto{\pgfpoint{-0.5\pgf@circ@res@up}{0.75\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint{0.5\pgf@circ@res@up}{-0.75\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint{1\pgf@circ@res@up}{0\pgf@circ@res@up}}
+			\pgfusepath{draw}
+		\endpgfscope
+}
+
 
 %% Independent current source
 
@@ -1063,6 +1081,49 @@
 	\pgfusepath{draw}
 
 	\pgfnode{circle}{center}{\textbf{A}}{}{}
+}
+
+%% Ohmmeter – contributed by Ralf Farkas
+
+\pgfcircdeclarebipole{}{\ctikzvalof{bipoles/ohmmeter/height}}{ohmmeter}{\ctikzvalof{bipoles/ohmmeter/height}}{\ctikzvalof{bipoles/ohmmeter/width}}{
+	\def\pgf@circ@temp{right}
+	\ifx\tikz@res@label@pos\pgf@circ@temp
+		\pgf@circ@res@step=-1.2\pgf@circ@res@up
+	\else
+		\def\pgf@circ@temp{below}
+		\ifx\tikz@res@label@pos\pgf@circ@temp
+			\pgf@circ@res@step=-1.2\pgf@circ@res@up
+		\else
+			\pgf@circ@res@step=1.2\pgf@circ@res@up
+		\fi
+	\fi
+
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@zero}}		
+	\pgfpointorigin	\pgf@circ@res@other =  \pgf@x  \advance \pgf@circ@res@other by -\pgf@circ@res@up
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@zero}}
+	\pgfusepath{draw}
+
+	\pgfsetlinewidth{\pgfkeysvalueof{/tikz/circuitikz/bipoles/thickness}\pgfstartlinewidth}
+
+		\pgfscope
+			\pgfpathcircle{\pgfpointorigin}{.9\pgf@circ@res@up}
+			\pgfusepath{draw}		
+		\endpgfscope	
+
+	\pgfsetlinewidth{\pgfstartlinewidth}
+
+	\pgfsetarrowsend{latex}
+	\pgfpathmoveto{\pgfpoint{\pgf@circ@res@other}{\pgf@circ@res@down}}
+	\pgfpathlineto{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@up}}
+	\pgfusepath{draw}
+	\pgfsetarrowsend{}
+
+	
+	\pgfpathmoveto{\pgfpoint{-\pgf@circ@res@other}{\pgf@circ@res@zero}}
+	\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@zero}}
+	\pgfusepath{draw}
+
+	\pgfnode{circle}{center}{\boldmath$\Omega$}{}{}
 }
 
 %% Voltmeter


### PR DESCRIPTION
Dear mredaelli,

some minutes ago, I wrote you an eMail concering some symbols I miss in circuitikz... then I realized that you have a git repository and forked your work for some minor modifications. I added two new symbols, a Triangular Voltage Symbol (based on the Square Voltage Symbol) and an Ohmmeter, similar to the Ampère- and Voltmeter you already had in your package. I chose to add these two symbols because
* they are universal, used in (as far as I know) every language
* they match the style of already existing symbols and extend the range in a logical way

I would like / can add other symbols as well, but I wanted to hear your opinion, because it is your package and I do not want to "ruin" your work ;)

Greetings from Karlsruhe, Germany,

Ralf (peaxels)

![demo](https://f.cloud.github.com/assets/898513/185097/ad20c71e-7cfa-11e2-8e81-cae1a55dfc11.png)