### PR TITLE
Add thickoxid mos (nmos, pmos)

### DIFF
--- a/tex/latex/circuitikz/circuitikz.code.tex
+++ b/tex/latex/circuitikz/circuitikz.code.tex
@@ -323,6 +323,22 @@
 \ctikzset{tripoles/isfet/waves y sep/.initial=.22}
 \ctikzset{tripoles/isfet/waves x sep/.initial=.8}
 
+\ctikzset{tripoles/nmos_thickoxid/width/.initial=.7}
+\ctikzset{tripoles/nmos_thickoxid/gate height/.initial=.35}
+\ctikzset{tripoles/nmos_thickoxid/base height/.initial=.35}
+\ctikzset{tripoles/nmos_thickoxid/height/.initial=1.1}
+\ctikzset{tripoles/nmos_thickoxid/base width/.initial=.32}
+\ctikzset{tripoles/nmos_thickoxid/gate width/.initial=.42}
+
+\ctikzset{tripoles/pmos_thickoxid/width/.initial=.7}
+\ctikzset{tripoles/pmos_thickoxid/gate height/.initial=.35}
+\ctikzset{tripoles/pmos_thickoxid/base height/.initial=.35}
+\ctikzset{tripoles/pmos_thickoxid/height/.initial=1.1}
+\ctikzset{tripoles/pmos_thickoxid/base width/.initial=.32}
+\ctikzset{tripoles/pmos_thickoxid/gate width/.initial=.42}
+\ctikzset{tripoles/pmos_thickoxid/triangle width/.initial=0}
+
+
 \newif\ifpgf@circuit@europeanlogicport
 \ctikzset{logic ports/.is choice}
 \ctikzset{logic ports/european/.code= {\pgf@circuit@europeanlogicporttrue } }

--- a/tex/latex/circuitikz/pgfcirctripoles.sty
+++ b/tex/latex/circuitikz/pgfcirctripoles.sty
@@ -3286,4 +3286,164 @@
 }
 
 
+\pgfcircdeclaremos{nmos_thickoxid}{
+		  \anchor{D}{
+			\northeast
+		  }
+		  \anchor{drain}{
+			\northeast
+		  }
+		  \anchor{S}{
+			\northeast
+			\pgf@y=-\pgf@y
+		  }
+		  \anchor{source}{
+			\northeast
+			\pgf@y=-\pgf@y
+		  }
+}{%
+			\pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@up}}
+
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base height}\pgf@circ@res@down}}
+
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}		
+			\pgfusepath{draw}
+			
+			\pgfscope
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}}
+			\pgfsetlinewidth{3\pgflinewidth}
+			\pgfusepath{draw}
+			\endpgfscope
+			
+		\ifpgf@circuit@mos@arrows
+			\pgfscope             
+			\pgfslopedattimetrue 
+			\pgfallowupsidedownattimetrue
+			\pgfresetnontranslationattimefalse
+			\pgftransformlineattime{.6}{%
+				\pgfpoint%
+					{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate width}\pgf@circ@res@left}%
+					{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}%
+			}{%
+				\pgfpoint
+					{\pgf@circ@res@right}%
+					{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}%
+			}
+			\pgfnode{currarrow}{center}{}{}{\pgfusepath{stroke}}
+			\endpgfscope
+		\fi
+
+					
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate width}\pgf@circ@res@left}
+				{\pgf@circ@res@up+\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+\pgf@circ@res@down}}
+			\pgfusepath{draw}
+}
+
+\pgfcircdeclaremos{pmos_thickoxid}{
+		  \anchor{D}{
+			\northeast
+		  }
+		  \anchor{drain}{
+			\northeast
+		  }
+		  \anchor{S}{
+			\northeast
+			\pgf@y=-\pgf@y
+		  }
+		  \anchor{source}{
+			\northeast
+			\pgf@y=-\pgf@y
+		  }
+}{%
+			\pgfpathmoveto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@up}}
+
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base height}\pgf@circ@res@down}}
+
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@right}{\pgf@circ@res@down}}
+			
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint{-\pgfkeysvalueof{/tikz/circuitikz/tripoles/pmos_thickoxid/triangle width}\pgf@circ@res@left}{0}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/base width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}}
+			
+			\pgfusepath{draw}
+			
+			\pgfscope
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@up}}
+			\pgfpathlineto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate width}\pgf@circ@res@left}
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}}
+			\pgfsetlinewidth{3\pgflinewidth}
+			\pgfusepath{draw}
+			\endpgfscope
+			
+		\ifpgf@circuit@mos@arrows
+			\pgfscope             
+			\pgfslopedattimetrue 
+			\pgfallowupsidedownattimetrue
+			\pgfresetnontranslationattimefalse
+			\pgftransformlineattime{.6}{%
+				\pgfpoint%
+					{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate width}\pgf@circ@res@left}%
+					{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}%
+			}{%
+				\pgfpoint
+					{\pgf@circ@res@right}%
+					{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate height}\pgf@circ@res@down}%
+			}
+			\pgfnode{currarrow}{center}{}{}{\pgfusepath{stroke}}
+			\endpgfscope
+		\fi
+
+					
+			\pgfpathmoveto{\pgfpoint
+				{\pgfkeysvalueof{/tikz/circuitikz/tripoles/nmos_thickoxid/gate width}\pgf@circ@res@left}
+				{\pgf@circ@res@up+\pgf@circ@res@down}}
+			\pgfpathlineto{\pgfpoint{\pgf@circ@res@left}{\pgf@circ@res@up+\pgf@circ@res@down}}
+			\pgfusepath{draw}
+}
+
+
 \endinput


### PR DESCRIPTION
Introduction of a new symbol for thickoxid mos devices. Chip designers sometimes use this kind of symbol.